### PR TITLE
Fix missing symbols in generated PDF documents

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,7 @@ jobs:
     - name: Install Pandoc and LaTeX
       run: |
         sudo apt-get update
-        sudo apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-lang-cyrillic
+        sudo apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-lang-cyrillic fonts-dejavu
 
     - name: Generate Ukrainian PDF Documentation
       run: |


### PR DESCRIPTION
Add fonts-dejavu package to install DejaVu Sans font which is used by pandoc for PDF generation but was not explicitly installed.