### PR TITLE
Fix deployment warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,7 @@ jobs:
           --number-sections \
           -V geometry:margin=1in \
           -V mainfont="DejaVu Sans" \
+          -V monofont="DejaVu Sans Mono" \
           -V documentclass=report \
           -V header-includes='\usepackage{float} \floatplacement{figure}{H}' \
           --resource-path=.:imgs \
@@ -204,6 +205,7 @@ jobs:
           --number-sections \
           -V geometry:margin=1in \
           -V mainfont="DejaVu Sans" \
+          -V monofont="DejaVu Sans Mono" \
           -V documentclass=report \
           -V header-includes='\usepackage{float} \floatplacement{figure}{H}' \
           --resource-path=.:imgs \


### PR DESCRIPTION
The lmmono10-regular font doesn't support Cyrillic characters, causing warnings during PDF generation. Use DejaVu Sans Mono for monospace text to ensure proper rendering of Ukrainian text in code blocks and inline code.