### PR TITLE
Update GitHub wait task for PyPI package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,30 +320,27 @@ jobs:
           binaries/webquiz-macos-apple-silicon/webquiz-macos-apple-silicon.zip \
           binaries/webquiz-windows.exe/webquiz-windows.exe.zip
 
-    - name: Wait for package to appear on PyPI
+    - name: Wait for package to be downloadable from PyPI
       run: |
-        echo "Waiting for webquiz ${{ github.event.inputs.version }} to appear on PyPI..."
-
+        echo "Waiting for webquiz ${{ github.event.inputs.version }} to be downloadable from PyPI..."
         MAX_ATTEMPTS=30
         ATTEMPT=1
         WAIT_TIME=10
-
+        # Create temporary directory for download test
+        TEMP_DIR=$(mktemp -d)
+        trap "rm -rf $TEMP_DIR" EXIT
         while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-          echo "Attempt $ATTEMPT/$MAX_ATTEMPTS: Checking PyPI..."
-
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/webquiz/${{ github.event.inputs.version }}/json")
-
-          if [ "$HTTP_CODE" = "200" ]; then
-            echo "✅ Package webquiz ${{ github.event.inputs.version }} is now available on PyPI!"
+          echo "Attempt $ATTEMPT/$MAX_ATTEMPTS: Trying to download package..."
+          # Use pip download to verify package is actually downloadable (not just metadata)
+          if pip download --no-deps --dest "$TEMP_DIR" "webquiz==${{ github.event.inputs.version }}" 2>/dev/null; then
+            echo "✅ Package webquiz ${{ github.event.inputs.version }} is now downloadable from PyPI!"
             exit 0
           fi
-
-          echo "Package not yet available (HTTP $HTTP_CODE). Waiting ${WAIT_TIME}s before retry..."
+          echo "Package not yet downloadable. Waiting ${WAIT_TIME}s before retry..."
           sleep $WAIT_TIME
           ATTEMPT=$((ATTEMPT + 1))
         done
-
-        echo "❌ Timeout: Package did not appear on PyPI after $MAX_ATTEMPTS attempts"
+        echo "❌ Timeout: Package was not downloadable from PyPI after $MAX_ATTEMPTS attempts"
         exit 1
 
     - name: Update webquiz-ansible repository


### PR DESCRIPTION
Change the wait step to actually download the package instead of just checking metadata availability. This ensures the package is truly downloadable before proceeding with dependent steps.