### PR TITLE
Fix broken fonts on quiz page

### DIFF
--- a/webquiz/server.py
+++ b/webquiz/server.py
@@ -679,7 +679,7 @@ class TestingServer:
         Raises:
             Various exceptions if file cannot be read or parsed
         """
-        async with aiofiles.open(quiz_file_path, "r") as f:
+        async with aiofiles.open(quiz_file_path, "r", encoding="utf-8") as f:
             content = await f.read()
             data = yaml.safe_load(content)
             self.questions = data["questions"]
@@ -864,7 +864,7 @@ class TestingServer:
             self.user_responses.clear()
 
             mode = "w" if not file_exists else "a"
-            async with aiofiles.open(self.csv_file, mode) as f:
+            async with aiofiles.open(self.csv_file, mode, encoding="utf-8") as f:
                 await f.write(csv_content)
 
             action = "Created" if not file_exists else "Updated"


### PR DESCRIPTION
Add explicit encoding="utf-8" to aiofiles.open() calls that were missing it, which caused Cyrillic characters in quiz titles to display as garbled text on systems where the default encoding is not UTF-8.

- server.py:682: Fix quiz file reading (quiz title was broken)
- server.py:867: Fix CSV file writing (user data with Cyrillic)