### PR TITLE
Change quiz file attachment URL from /files/ to /attach/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ WebQuiz - Python/aiohttp quiz system with multi-quiz management, real-time WebSo
 
 **Public:**
 - `POST /api/register`, `PUT /api/update-registration`, `POST /api/submit-answer`, `GET /api/verify-user/{user_id}`
-- `GET /files/{filename}` - Download quiz file attachment (Content-Disposition: attachment)
+- `GET /attach/{filename}` - Download quiz file attachment (Content-Disposition: attachment)
 
 **Admin (session cookie required, local network only):**
 - `POST /api/admin/auth` - Authenticate with master key in request body (`{"master_key": "..."}`)
@@ -126,7 +126,7 @@ webquiz-stress-test -c 50
 - **Quiz download folder validation** - Path traversal protection: blocks "..", absolute paths (Unix/Windows), normalizes paths, ensures extraction stays within quizzes directory; allows subfolder paths like "folder/subfolder/"
 - **Clipboard API fallback** - Copy public key button uses modern navigator.clipboard API for HTTPS/localhost, falls back to document.execCommand() for non-secure contexts (HTTP over IP)
 - **Package version check** - Admin panel periodically checks if package was updated while server is running by comparing in-memory version with file version; shows "Restart Required" banner when mismatch detected
-- **Quiz file attachments** - Questions can have downloadable files via `file` field (e.g., `file: "data.xlsx"`). Files stored in `quizzes/files/`, served at `/files/{filename}` with `Content-Disposition: attachment` header for forced download. Server auto-prepends `/files/` when serving to client. Admin panel has file picker modal for selecting files.
+- **Quiz file attachments** - Questions can have downloadable files via `file` field (e.g., `file: "data.xlsx"`). Files stored in `quizzes/files/`, served at `/attach/{filename}` with `Content-Disposition: attachment` header for forced download. Server auto-prepends `/attach/` when serving to client. Admin panel has file picker modal for selecting files.
 
 ## Key Flows
 

--- a/webquiz/server.py
+++ b/webquiz/server.py
@@ -766,11 +766,11 @@ class TestingServer:
             # Include optional image attribute if present
             if "image" in q and q["image"]:
                 client_question["image"] = q["image"]
-            # Include optional file attribute if present (prepend /files/ if not already there)
+            # Include optional file attribute if present (prepend /attach/ if not already there)
             if "file" in q and q["file"]:
                 file_path = q["file"]
-                if not file_path.startswith("/files/"):
-                    file_path = f"/files/{file_path}"
+                if not file_path.startswith("/attach/"):
+                    file_path = f"/attach/{file_path}"
                 client_question["file"] = file_path
             # Include min_correct for multiple choice questions
             if isinstance(q["correct_answer"], list):
@@ -1407,10 +1407,10 @@ class TestingServer:
         if user_id not in self.user_answers:
             self.user_answers[user_id] = []
 
-        # Normalize file path for results (prepend /files/ if needed)
+        # Normalize file path for results (prepend /attach/ if needed)
         file_value = question.get("file")
-        if file_value and not file_value.startswith("/files/"):
-            file_value = f"/files/{file_value}"
+        if file_value and not file_value.startswith("/attach/"):
+            file_value = f"/attach/{file_value}"
 
         answer_data = {
             "question": question.get("question", ""),  # Handle image-only questions
@@ -2414,7 +2414,7 @@ class TestingServer:
                 file_list.append(
                     {
                         "filename": filename,
-                        "path": f"/files/{filename}",
+                        "path": f"/attach/{filename}",
                         "size": file_size,
                     }
                 )
@@ -3211,8 +3211,8 @@ async def create_app(config: WebQuizConfig):
 
     # File management routes (admin access)
     app.router.add_get("/files/", server.serve_files_page)
-    # Quiz file download route (must be after /files/ to avoid conflict)
-    app.router.add_get("/files/{filename}", server.serve_quiz_file)
+    # Quiz file attachment download route
+    app.router.add_get("/attach/{filename}", server.serve_quiz_file)
     app.router.add_get("/api/files/list", server.files_list)
     app.router.add_get("/api/files/{type}/view/{filename}", server.files_view)
     app.router.add_get("/api/files/{type}/download/{filename}", server.files_download)

--- a/webquiz/templates/admin.html
+++ b/webquiz/templates/admin.html
@@ -2074,8 +2074,8 @@
                 return;
             }
 
-            // Extract just the filename from the path (remove /files/ prefix)
-            const filename = filePath.replace(/^\/files\//, '');
+            // Extract just the filename from the path (remove /attach/ prefix)
+            const filename = filePath.replace(/^\/attach\//, '');
 
             // Find the question div by question ID
             const questionDiv = document.querySelector(`[data-question-id="${currentFileQuestionId}"]`);


### PR DESCRIPTION
This change moves the quiz file attachment endpoint from /files/{filename} to /attach/{filename} to avoid confusion with the file manager page at /files/.